### PR TITLE
Fix apps with bad WebRTC versions

### DIFF
--- a/programmable_video/android/build.gradle
+++ b/programmable_video/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.6.10'
-    ext.twilio_video_version = '7.6.+'
+    ext.twilio_video_version = '7.6.4'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
### Related Issues

Please list any related issues that this pull request resolves or is related to:

Notion: [link_here](https://www.notion.so/wesionary-team/WebRTC-3a21956192614ec5b1cae6cf600df9d5)

The SDK version specification was dynamic, so I changed it to fixed.
I chose the latest 7.6.4 because it was not supported in 7.6.0 .

Twilio SDK Page
`Updated to now use WebRTC-m105`
https://www.twilio.com/docs/video/changelog-twilio-video-android-v7#761-mar-27-2023

Google support Page
`It is strongly recommended that apps update to the current source, though updating to M102 or later will remediate the security issue.`
https://support.google.com/faqs/answer/12577537?hl=en
