### PR TITLE
SOUD-376 | Resolve "EGLRenderer is still running after disconnect/dispose the room"

### DIFF
--- a/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/ParticipantView.kt
+++ b/programmable_video/android/src/main/kotlin/twilio/flutter/twilio_programmable_video/ParticipantView.kt
@@ -4,7 +4,7 @@ import com.twilio.video.VideoTrack
 import com.twilio.video.VideoView
 import io.flutter.plugin.platform.PlatformView
 
-class ParticipantView(private var videoView: VideoView, videoTrack: VideoTrack) : PlatformView {
+class ParticipantView(private var videoView: VideoView, private var videoTrack: VideoTrack) : PlatformView {
     private val TAG = "ParticipantView"
 
     init {
@@ -17,6 +17,8 @@ class ParticipantView(private var videoView: VideoView, videoTrack: VideoTrack) 
 
     override fun dispose() {
         debug("dispose => Disposing ParticipantView")
+        videoTrack.removeSink(videoView)
+        videoView.release()
     }
 
     internal fun debug(msg: String) {


### PR DESCRIPTION
Ref : https://gitlab.com/twilio-flutter/programmable-video/-/merge_requests/159/diffs